### PR TITLE
Add jest testing setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -39,6 +40,11 @@
     "eslint-config-next": "15.3.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.2.9",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.4",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/jest-dom": "^6.1.0"
   }
 }

--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useAuth } from '@/hooks/useAuth';
+
+function TestComponent() {
+  useAuth();
+  return null;
+}
+
+describe('useAuth', () => {
+  it('throws when called outside an AuthProvider', () => {
+    expect(() => render(<TestComponent />)).toThrow('useAuth must be used within an AuthProvider');
+  });
+});


### PR DESCRIPTION
## Summary
- add jest, ts-jest and React Testing Library to dev dependencies
- provide jest config and setup file
- add a failing test that checks `useAuth` outside `AuthProvider`
- expose `test` npm script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a55aa61c832a85e774d6c47783a7